### PR TITLE
Remove redundant info from webhook posts

### DIFF
--- a/zhook.py
+++ b/zhook.py
@@ -112,15 +112,37 @@ class MattermostWebhookBody:
   def addPullRequestDetails(self):
     self.body["text"] = self.createTitle()
     prJson = self.eventJson["pull_request"]
+    headJson = prJson["head"]
+    baseJson = prJson["base"]
     self.attachment["color"] = self.prColor
-    self.attachment["title"] = prJson["title"]
-    self.attachment["title_link"] = prJson["html_url"]
+    bodyTxt = f"Pull request [PR#{prJson['number']}: {prJson['title']}]({prJson['html_url']}):\n"
+    bodyTxt += f"{headJson['label']} -> {baseJson['label']}"
 
-    # bodyTxt = prJson['body']
-    # if bodyTxt is not None:
-    #   self.attachment["text"] = bodyTxt
+    try:
+      reviewers = prJson["requested_reviewers"]
+      bodyText += "Reviewer(s):"
+      for r in reviewers:
+        bodyText += f" [{r['login']}]({r['html_url']}),"
+    except Exception:
+      pass
+
+    try:
+      reviewers = prJson["requested_teams"]
+      for r in reviewers:
+        bodyText += f" [{r['name']}]({r['html_url']}),"
+    except Exception:
+      pass
+
+    bodyText = bodyText.rstrip(',')
+    bodyText += "\n"
+
+    try:
+      bodyTxt += f"{prJson['body']}"
+    except Exception:
+      pass
 
     self.attachment["color"] = self.prColor
+    self.attachment["text"] = bodyTxt
     self.attachment["thumb_url"] = self.prThumbnail
 
   def addPullRequestReviewCommentDetails(self):

--- a/zhook.py
+++ b/zhook.py
@@ -159,7 +159,7 @@ class MattermostWebhookBody:
       bodyTxt += f"{commentJson['body']}"
     except Exception:
       pass
-    
+
     self.attachment["color"] = self.prColor
     self.attachment["text"] = bodyTxt
 

--- a/zhook.py
+++ b/zhook.py
@@ -157,7 +157,8 @@ class MattermostWebhookBody:
       bodyTxt += f"{commentJson['body']}"
     except Exception:
       pass
-
+    
+    bodyTxt += "\n#new-pull-request"
     self.attachment["color"] = self.prColor
     self.attachment["text"] = bodyTxt
 

--- a/zhook.py
+++ b/zhook.py
@@ -120,21 +120,21 @@ class MattermostWebhookBody:
 
     try:
       reviewers = prJson["requested_reviewers"]
-      bodyText += "Reviewer(s):"
+      bodyTxt += "Reviewer(s):"
       for r in reviewers:
-        bodyText += f" [{r['login']}]({r['html_url']}),"
+        bodyTxt += f" [{r['login']}]({r['html_url']}),"
     except Exception:
       pass
 
     try:
       reviewers = prJson["requested_teams"]
       for r in reviewers:
-        bodyText += f" [{r['name']}]({r['html_url']}),"
+        bodyTxt += f" [{r['name']}]({r['html_url']}),"
     except Exception:
       pass
 
-    bodyText = bodyText.rstrip(',')
-    bodyText += "\n"
+    bodyTxt = bodyTxt.rstrip(',')
+    bodyTxt += "\n"
 
     try:
       bodyTxt += f"{prJson['body']}"

--- a/zhook.py
+++ b/zhook.py
@@ -116,9 +116,9 @@ class MattermostWebhookBody:
     self.attachment["title"] = prJson["title"]
     self.attachment["title_link"] = prJson["html_url"]
 
-    bodyTxt = prJson['body']
-    if bodyTxt is not None:
-      self.attachment["text"] = bodyTxt
+    # bodyTxt = prJson['body']
+    # if bodyTxt is not None:
+    #   self.attachment["text"] = bodyTxt
 
     self.attachment["color"] = self.prColor
     self.attachment["thumb_url"] = self.prThumbnail

--- a/zhook.py
+++ b/zhook.py
@@ -7,11 +7,11 @@ import os
 
 class MattermostWebhookBody:
   actionRepoIcon = "https://github.com/openziti/branding/blob/main/images/ziggy/png/Ziggy-Gits-It.png?raw=true"
-  prThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/png/Ziggy%20Chef.png?raw=true"
+  prThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/closeups/Ziggy-Chef-Closeup.png?raw=true"
   prApprovedThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/closeups/Ziggy-Dabbing.png?raw=true"
   issueThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/closeups/Ziggy-has-an-Idea-Closeup.png?raw=true"
   # releaseThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/png/Ziggy-Cash-Money-Closeup.png?raw=true"
-  releaseThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/png/Ziggy%20Parties.png?raw=true"
+  releaseThumbnail = "https://github.com/openziti/branding/blob/main/images/ziggy/closeups/Ziggy-Parties-Closeup.png?raw=true"
 
   prColor = "#32CD32"
   pushColor = "#708090"
@@ -31,18 +31,22 @@ class MattermostWebhookBody:
     self.senderJson = self.eventJson["sender"]
 
     self.body = {
-      "username": self.username,
-      "icon_url": self.icon,
+      # "username": self.username,
+      # "icon_url": self.icon,
+      "username": self.senderJson['login'],
+      "icon_url": self.senderJson['avatar_url'],
       "channel": self.channel,
       "props": {"card": f"```json\n{self.eventJsonStr}\n```"},
     }
 
+    # self.attachment = {
+    #   "author_name": self.senderJson['login'],
+    #   "author_icon": self.senderJson['avatar_url'],
+    #   "author_link": self.senderJson['html_url'],
+    #   "footer": self.actionRepo,
+    #   "footer_icon": self.actionRepoIcon,
+    # }
     self.attachment = {
-      "author_name": self.senderJson['login'],
-      "author_icon": self.senderJson['avatar_url'],
-      "author_link": self.senderJson['html_url'],
-      "footer": self.actionRepo,
-      "footer_icon": self.actionRepoIcon,
     }
 
     if eventName == "push":
@@ -114,11 +118,7 @@ class MattermostWebhookBody:
 
     bodyTxt = prJson['body']
     if bodyTxt is not None:
-      bodyTxt += "\n#new-pull-request"
-    else:
-      bodyTxt = "#new-pull-request"
-
-    self.attachment["text"] = bodyTxt
+      self.attachment["text"] = bodyTxt
 
     self.attachment["color"] = self.prColor
     self.attachment["thumb_url"] = self.prThumbnail

--- a/zhook.py
+++ b/zhook.py
@@ -143,6 +143,8 @@ class MattermostWebhookBody:
     except Exception:
       pass
 
+    bodyTxt += "\n#new-pull-request"
+
     self.attachment["color"] = self.prColor
     self.attachment["text"] = bodyTxt
     self.attachment["thumb_url"] = self.prThumbnail
@@ -158,7 +160,6 @@ class MattermostWebhookBody:
     except Exception:
       pass
     
-    bodyTxt += "\n#new-pull-request"
     self.attachment["color"] = self.prColor
     self.attachment["text"] = bodyTxt
 

--- a/zhook.py
+++ b/zhook.py
@@ -115,8 +115,8 @@ class MattermostWebhookBody:
     headJson = prJson["head"]
     baseJson = prJson["base"]
     self.attachment["color"] = self.prColor
-    bodyTxt = f"Pull request [PR#{prJson['number']}: {prJson['title']}]({prJson['html_url']}):\n"
-    bodyTxt += f"{headJson['label']} -> {baseJson['label']}"
+    bodyTxt = f"Pull request [PR#{prJson['number']}: {prJson['title']}]({prJson['html_url']})\n"
+    bodyTxt += f"{headJson['label']} -> {baseJson['label']}\n"
 
     try:
       reviewers = prJson["requested_reviewers"]
@@ -137,7 +137,9 @@ class MattermostWebhookBody:
     bodyTxt += "\n"
 
     try:
-      bodyTxt += f"{prJson['body']}"
+      bodyContent = prJson['body']
+      if bodyContent is not None:
+        bodyTxt += f"{bodyContent}"
     except Exception:
       pass
 


### PR DESCRIPTION
* Drop footer section
* Drop header section with sender/sender image
* Replace sender icon with Github user icon
* Add additional detail to new-PR webhook
* update thumbnails to use Ziggy close-ups